### PR TITLE
fix: request proxy only after registering redis pubsub event listeners

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -98,9 +98,9 @@ export default class Client {
     this.debug(`Proxy offered by ${clientId}`);
     this.removeHandlers();
     this.debug('Requesting proxy link');
-    this.pubsub.sendMessage(PROXY_LINK, clientId);
     this.pubsub.onceMessage(PROXY_LINK_DROP, this.onProxyLinkDrop);
     this.pubsub.onceMessage(PROXY_DELIVER, this.onProxyLink);
+    this.pubsub.sendMessage(PROXY_LINK, clientId);
   }
 
   onProxyLink(data) {


### PR DESCRIPTION
Previously, when requesting a proxy from a local redis instance it would sometimes not give a proxy but instead get the client stuck in the `onProxyOffer` client method. This would not happen with a remote redis instance, because there was a slight delay between asking redis for a proxy link and registering the event listeners.
Fix: move the "ask for a proxy link" call two lines down, so that the pubsub event listeners are registered before asking redis for a proxy link.